### PR TITLE
Added format line to json file

### DIFF
--- a/sample_configs.local.json
+++ b/sample_configs.local.json
@@ -1,6 +1,7 @@
 {
   "bam_input": {
         "class": "File",
+        "format": "http://edamontology.org/format_2572",
         "path": "/tmp/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam"
     },
     "bamstats_report": {

--- a/script.sh
+++ b/script.sh
@@ -7,6 +7,7 @@ set -o xtrace
 
 if [[ "${LANGUAGE}" == "cwl" ]]; then
     cwltool --non-strict Dockstore.cwl test.json
+    cwltool --non-strict Dockstore.cwl sample_configs.local.json
 elif [[ "${LANGUAGE}" == "wdl" ]]; then
     java -jar cromwell-32.jar run Dockstore.wdl --inputs test.wdl.json
 elif [[ "${LANGUAGE}" == "nfl" ]]; then

--- a/script.sh
+++ b/script.sh
@@ -7,6 +7,8 @@ set -o xtrace
 
 if [[ "${LANGUAGE}" == "cwl" ]]; then
     cwltool --non-strict Dockstore.cwl test.json
+    wget ftp://ftp.1000genomes.ebi.ac.uk/vol1/ftp/phase3/data/NA12878/alignment/NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam
+    mv NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam /tmp/
     cwltool --non-strict Dockstore.cwl sample_configs.local.json
 elif [[ "${LANGUAGE}" == "wdl" ]]; then
     java -jar cromwell-32.jar run Dockstore.wdl --inputs test.wdl.json


### PR DESCRIPTION
## Bug
In the dockstore tutorial "[Getting Started with CWL](https://docs.dockstore.org/docs/prereqs/getting-started-with-cwl/#testing-locally)", running the dockstore tool previously failed. The sample_configs.local.json was missing an input format.

## Fix
Added format line to sample_configs.local.json 