### PR TITLE
update wdl to version 1.0

### DIFF
--- a/Dockstore.wdl
+++ b/Dockstore.wdl
@@ -1,6 +1,10 @@
+version 1.0
 task bamstats {
-	File bam_input
-	Int mem_gb
+    input {
+        File bam_input
+        Int mem_gb
+    }
+
 
 	command {
 		bash /usr/local/bin/bamstats ${mem_gb} ${bam_input}
@@ -11,7 +15,7 @@ task bamstats {
 	}
 
 	runtime {
-		docker: "quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0" 
+		docker: "quay.io/collaboratory/dockstore-tool-bamstats:1.25-6_1.0"
 		memory: mem_gb + "GB"
 	}
 
@@ -21,7 +25,9 @@ task bamstats {
 }
 
 workflow bamstatsWorkflow {
-	File bam_input
-	Int mem_gb	
+    input {
+        File bam_input
+        Int mem_gb
+    }
 	call bamstats { input: bam_input=bam_input, mem_gb=mem_gb }
 }

--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ set -o xtrace
 if [[ "${LANGUAGE}" == "cwl" ]]; then
     pip2.7 install --user cwl-runner cwltool==1.0.20160712154127 schema-salad==1.14.20160708181155 avro==1.8.1
 elif [[ "${LANGUAGE}" == "wdl" ]]; then
-    wget https://github.com/broadinstitute/cromwell/releases/download/32/cromwell-32.jar
+    wget https://github.com/broadinstitute/cromwell/releases/download/44/cromwell-44.jar
 elif [[ "${LANGUAGE}" == "nfl" ]]; then
     curl -s https://get.nextflow.io | bash
     mv nextflow $HOME/bin

--- a/script.sh
+++ b/script.sh
@@ -11,7 +11,7 @@ if [[ "${LANGUAGE}" == "cwl" ]]; then
     mv NA12878.chrom20.ILLUMINA.bwa.CEU.low_coverage.20121211.bam /tmp/
     cwltool --non-strict Dockstore.cwl sample_configs.local.json
 elif [[ "${LANGUAGE}" == "wdl" ]]; then
-    java -jar cromwell-32.jar run Dockstore.wdl --inputs test.wdl.json
+    java -jar cromwell-44.jar run Dockstore.wdl --inputs test.wdl.json
 elif [[ "${LANGUAGE}" == "nfl" ]]; then
     nextflow run main.nf
 fi


### PR DESCRIPTION
It shows as failing on the test, but if I run it locally using cromwell-44 it is successful.

```# return exit code
exit $rc
[2019-09-12 14:47:05,51] [info] BackgroundConfigAsyncJobExecutionActor [677d3301bamstatsWorkflow.bamstats:NA:1]: job id: 62220
[2019-09-12 14:47:05,51] [info] BackgroundConfigAsyncJobExecutionActor [677d3301bamstatsWorkflow.bamstats:NA:1]: Status change from - to WaitingForReturnCode
[2019-09-12 14:48:22,11] [info] BackgroundConfigAsyncJobExecutionActor [677d3301bamstatsWorkflow.bamstats:NA:1]: Status change from WaitingForReturnCode to Done
[2019-09-12 14:48:22,56] [info] WorkflowExecutionActor-677d3301-9a6a-4048-89e8-a3751ffab6bc [677d3301]: Workflow bamstatsWorkflow complete. Final Outputs:
{
  "bamstatsWorkflow.bamstats.bamstats_report": "/Users/natalieperez/Projects/dockstore-tool-bamstats/cromwell-executions/bamstatsWorkflow/677d3301-9a6a-4048-89e8-a3751ffab6bc/call-bamstats/execution/bamstats_report.zip"
}
[2019-09-12 14:48:22,58] [info] WorkflowManagerActor WorkflowActor-677d3301-9a6a-4048-89e8-a3751ffab6bc is in a terminal state: WorkflowSucceededState
[2019-09-12 14:48:26,34] [info] SingleWorkflowRunnerActor workflow finished with status 'Succeeded'.
{
  "outputs": {
    "bamstatsWorkflow.bamstats.bamstats_report": "/Users/natalieperez/Projects/dockstore-tool-bamstats/cromwell-executions/bamstatsWorkflow/677d3301-9a6a-4048-89e8-a3751ffab6bc/call-bamstats/execution/bamstats_report.zip"
  },
  "id": "677d3301-9a6a-4048-89e8-a3751ffab6bc"
}
 ```